### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Run Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/commjoen/Topotest/security/code-scanning/3](https://github.com/commjoen/Topotest/security/code-scanning/3)

In general, the fix is to add an explicit `permissions` block that grants only the minimal necessary scopes to the `GITHUB_TOKEN`. For a pure test workflow that only checks out code and uploads artifacts, `contents: read` is sufficient, and no write permissions are required.

The best way to fix this without changing functionality is to add a top-level `permissions` block (applies to all jobs) in `.github/workflows/test.yml` just after the `name` (line 1) and before the `on` key (line 3). This block should set `contents: read`, which allows the checkout action to function while avoiding accidental write permissions to the repository. No changes are needed inside the `jobs` section or steps, and no imports or additional methods are required.

Concretely:
- Edit `.github/workflows/test.yml`.
- Insert:
  ```yaml
  permissions:
    contents: read
  ```
  between line 1 (`name: Run Tests`) and line 3 (`on:`).  
This will satisfy CodeQL’s requirement and document the intended minimal permissions for this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
